### PR TITLE
Bugfix/iphone 13 pro

### DIFF
--- a/Sources/SimpleEncryptor/KeyService/KeyService.swift
+++ b/Sources/SimpleEncryptor/KeyService/KeyService.swift
@@ -32,7 +32,7 @@ struct KeychainKeyService: KeyService {
 	func createKey() throws -> SymmetricKey {
 		let newKey = SymmetricKey(size: .bits256) //create new key
 		var query = param.queryDictionary
-		query[kSecAttrAccessible] = param.keyAccess
+		query[kSecAttrAccessible] = param.keyAccess.value
 		query[kSecValueData] = newKey.dataRepresentation //request to get the result (key) as data
 		
 		let status = SecItemAdd(query as CFDictionary, nil)

--- a/Tests/Tests/CBCTests.swift
+++ b/Tests/Tests/CBCTests.swift
@@ -47,7 +47,7 @@ class CBCTests: XCTestCase {
 		XCTAssertEqual(data, decrypted)
 	}
 
-	func testShouldCipherFileSuccess() throws {
+	func testShouldCipherStreamSuccess() throws {
 		//Given
 		let data = Data(randomString(length: 10_000).utf8)
 		let encrypted = try AES.CBC.encrypt(data, using: key, iv: iv)


### PR DESCRIPTION
FIXED issue on iPhone 13 pro, where could not store keys to keychain (using `KeyAccess` instead of `CFString`)
RENAMED test method
